### PR TITLE
AudioKeyHBox: fix removing already deleted key

### DIFF
--- a/addons/rhubarb_lipsync_integration/RhubarbLipsyncImporter/boxes/AudioKeyHBox.gd
+++ b/addons/rhubarb_lipsync_integration/RhubarbLipsyncImporter/boxes/AudioKeyHBox.gd
@@ -56,7 +56,7 @@ func _on_PopupMenu_item_selected(id :int):
 
 func _clear_clip_path_array():
 	for i in clip_path.size():
-		clip_path.remove(i)
+		clip_path.remove(0)
 
 func _on_Button_pressed():
 	popupMenu.clear()


### PR DESCRIPTION
At the second time forward you select a audiokey the bug tried to remove already deleted keys from clip_path Array when called the clear function. This is a rookie mistake of mine.